### PR TITLE
Changelog check in Docker and typing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!changelog_check.py

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 *
 !changelog_check.py
+!wazo_hook_utils.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.0
+    rev: v1.7.1
     hooks:
       - id: mypy
         language_version: "3.10"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,7 @@ repos:
     hooks:
       - id: mypy
         language_version: "3.10"
+  - repo: https://github.com/wazo-platform/wazo-git-hooks
+    rev: 1.0.0
+    hooks:
+      - id: wazo-copyright-check

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,7 +8,7 @@
   description: check wazo copyright notices in source file headers of updated file
   language: script
   entry: copyright_check.py
-  pass_filenames: false
+  pass_filenames: true
   stages: [commit, push, manual]
   exclude_types: [binary]
 - id: wazo-changelog-check
@@ -16,7 +16,7 @@
   description: check that debian/changelog file has been updated along with commit
   language: docker
   entry: /changelog_check.py
-  pass_filenames: false
+  pass_filenames: true
   stages: [commit, push, manual]
 - id: wazo-local-docker-volume-check
   name: check local docker volume

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -14,8 +14,8 @@
 - id: wazo-changelog-check
   name: update debian changelog
   description: check that debian/changelog file has been updated along with commit
-  language: script
-  entry: changelog_check.py
+  language: docker
+  entry: /changelog_check.py
   pass_filenames: false
   stages: [commit, push, manual]
 - id: wazo-local-docker-volume-check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:bullseye-slim
+RUN apt-get update -q \
+        && apt-get install -y git dh-make locales locales-all \
+        && rm -rf /var/lib/apt/lists/* \
+        && locale-gen en_US.UTF-8
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+COPY changelog_check.py /changelog_check.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
+COPY wazo_hook_utils.py /wazo_hook_utils.py
 COPY changelog_check.py /changelog_check.py

--- a/changelog_check.py
+++ b/changelog_check.py
@@ -1,49 +1,41 @@
 #!/usr/bin/env python3
 # Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
-import os
 import re
 import subprocess
 import sys
 
+from wazo_hook_utils import get_files_to_check
 
-def main():
+
+def main() -> None:
     if not should_run():
         return
 
-    files = list_files_to_commit()
+    files = get_files_to_check()
 
     if 'debian/changelog' not in files:
         print("Please update the changelog before committing.")
         sys.exit(1)
 
 
-def should_run():
+def should_run() -> bool:
     cmd = ['dpkg-parsechangelog', '--show-field', 'Version']
-    result = subprocess.run(cmd, stdout=subprocess.PIPE)
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, text=True)
     command_exists = result.returncode != 127
     if not command_exists:
         result.check_returncode()
     changelog_exists = result.returncode != 255
     if not changelog_exists:
         return False
-    changelog_version = result.stdout.strip().decode('utf-8')
+    changelog_version = result.stdout.strip()
     is_repackaged_by_wazo = re.match(r'^.*~(xivo|wazo)[0-9]', changelog_version)
     cmd = ['dpkg-parsechangelog', '--show-field', 'Source']
-    changelog_package = subprocess.check_output(cmd).strip().decode('utf-8')
+    changelog_package = subprocess.check_output(cmd, text=True).strip()
     is_packaging = changelog_package.endswith('-packaging')
-    return is_packaging or is_repackaged_by_wazo
-
-
-def list_files_to_commit():
-    cmd = ['git', 'diff', '--cached', '--name-only', '--diff-filter=MA']
-    output = subprocess.check_output(cmd).strip().decode('utf-8')
-    if not output:
-        return []
-    return [
-        line.strip() for line in output.split("\n") if not os.path.islink(line.strip())
-    ]
+    return bool(is_packaging or is_repackaged_by_wazo)
 
 
 if __name__ == "__main__":

--- a/local_docker_volume_check.py
+++ b/local_docker_volume_check.py
@@ -7,15 +7,13 @@ import subprocess
 import sys
 
 
-def main():
-    files = list_files_changed_with_local_git_repos()
-
-    if files:
+def main() -> None:
+    if list_files_changed_with_local_git_repos():
         print("ERROR: Modification with LOCAL_GIT_REPOS detected. Refusing to commit.")
         sys.exit(1)
 
 
-def list_files_changed_with_local_git_repos():
+def list_files_changed_with_local_git_repos() -> list[str]:
     """
     We do not want commits containing uncommented lines using LOCAL_GIT_REPOS.
     Those lines should stay commented when committed
@@ -28,7 +26,7 @@ def list_files_changed_with_local_git_repos():
         '--name-only',
         r'-G^\s+-\s+"?\$\{LOCAL_GIT_REPOS\}',
     ]
-    output = subprocess.check_output(cmd).strip().decode('utf-8')
+    output = subprocess.check_output(cmd, text=True).strip()
     if not output:
         return []
     return [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,13 @@ python_version = "3.10"
 show_error_codes = true
 check_untyped_defs = true
 warn_unused_configs = true
-follow_imports = "skip"
-ignore_missing_imports = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+warn_unused_ignores = true
+strict_equality = true
+extra_checks = true
+no_warn_no_return = true
 
 [tool.black]
 skip-string-normalization = true

--- a/wazo_hook_utils.py
+++ b/wazo_hook_utils.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from os import path
+
+
+def list_files_to_commit() -> list[str]:
+    """
+    Return a list of all staged files.
+    """
+    cmd = ['git', 'diff', '--cached', '--name-only', '--diff-filter=MA']
+    output = subprocess.check_output(cmd, text=True).strip()
+    if not output:
+        return []
+    return [
+        line.strip() for line in output.split("\n") if not path.islink(line.strip())
+    ]
+
+
+def get_files_to_check() -> list[str]:
+    """
+    Pre-commit will pass files as arguments to script or not call it at all.
+    If no arguments are received, we will assume we are running as standalone
+    And find the files ourselves.
+    """
+    if files := sys.argv[1:]:
+        return files
+    return list_files_to_commit()


### PR DESCRIPTION
- Run changelog checks in Docker since not everyone is on Debian and even then not the correct version. 
- Add typing
- Check if file names passed as arguments and if so, use them instead of trying to find them again
- Move some duplicated code to a helpers file