### PR TITLE
Fix copyright check to only parse specified files if they are staged

### DIFF
--- a/copyright_check.py
+++ b/copyright_check.py
@@ -8,7 +8,7 @@ import sys
 
 from datetime import datetime
 
-from wazo_hook_utils import get_files_to_check
+from wazo_hook_utils import list_files_to_commit
 
 COPYRIGHT_TPL = "{}Copyright {}-{} The Wazo Authors  (see the AUTHORS file)"
 COPYRIGHT_REGEX = re.compile(
@@ -18,7 +18,12 @@ COPYRIGHT_REGEX = re.compile(
 
 def main() -> None:
     abort = False
-    for file_path in get_files_to_check():
+
+    files_to_check = list_files_to_commit()
+    if specified_files := sys.argv[1:]:
+        files_to_check = [f for f in specified_files if f in files_to_check]
+
+    for file_path in files_to_check:
         copyright_text = find_copyright(file_path)
         if copyright_text is None:
             print(f"WARNING: {file_path} has no copyright")


### PR DESCRIPTION
reason: Otherwise running pre-commit --all-files will update copyright in all files, which is not the desired behavior